### PR TITLE
OMID-167 fix flaky TestTSOChannelHandlerNetty

### DIFF
--- a/common/src/main/java/org/apache/omid/NetworkUtils.java
+++ b/common/src/main/java/org/apache/omid/NetworkUtils.java
@@ -17,15 +17,19 @@
  */
 package org.apache.omid;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
+import java.net.ServerSocket;
 import java.net.SocketException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.List;
 
 public class NetworkUtils {
 
@@ -69,5 +73,33 @@ public class NetworkUtils {
 
         throw new IllegalArgumentException(String.format("No network '%s*'/'%s*' interfaces found",
                                                          MAC_TSO_NET_IFACE_PREFIX, LINUX_TSO_NET_IFACE_PREFIX));
+    }
+
+    public static int availablePort() {
+        return availablePorts(1).get(0);
+    }
+
+    public static List<Integer> availablePorts(int count) {
+        List<ServerSocket> servers = new ArrayList<>();
+        List<Integer> availablePorts = new ArrayList<>();
+        IOException lastError= null;
+        try {
+            for (int i = 0; i < count; ++i) {
+                servers.add(new ServerSocket(0));
+            }
+        } catch (IOException e) {
+            lastError = e;
+        } finally {
+            for (ServerSocket s : servers) {
+                availablePorts.add(s.getLocalPort());
+                try {
+                    s.close();
+                } catch (IOException e) {
+                    lastError = e;
+                }
+            }
+        }
+        if (lastError != null) throw new RuntimeException(lastError);
+        return availablePorts;
     }
 }


### PR DESCRIPTION
issue: https://issues.apache.org/jira/browse/OMID-167

The port is not free immediately after we close the channel. Hence, we should use different port for each test case.

This PR includes a bit refactor.