### PR TITLE
OMID-187 Fix incorrect URL of source code

### DIFF
--- a/doc/site/site.xml
+++ b/doc/site/site.xml
@@ -72,7 +72,7 @@
         </menu>
 
         <menu name="Contribute">
-            <item name="Source Code" href="https://git-wip-us.apache.org/repos/asf/incubator-omid.git" />
+            <item name="Source Code" href="https://git-wip-us.apache.org/repos/asf/phoenix-omid.git" />
             <item name="JIRA" href="https://issues.apache.org/jira/browse/Omid" />
             <item name="Mailing Lists" href="mailing-lists.html" />
             <item name="Coding Guide and Style" href="coding-guide-and-style.html" />


### PR DESCRIPTION
issue: https://issues.apache.org/jira/browse/OMID-187

https://git-wip-us.apache.org/repos/asf/incubator-omid.git is not available and the replacement is https://git-wip-us.apache.org/repos/asf/phoenix-omid.git