### PR TITLE
OMID-188 Fix "inconsistent module metadata found" when using hbase-2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .project
 .settings
 .metadata
+.flattened-pom.xml
 dependency-reduced-pom.xml
 target/
 lib/

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -18,11 +18,11 @@
 
     <parent>
         <groupId>org.apache.omid</groupId>
-        <artifactId>omid</artifactId>
+        <artifactId>omid-${hbase.artifactId.suffix}</artifactId>
         <version>1.0.2-SNAPSHOT</version>
     </parent>
 
-    <artifactId>omid-benchmarks</artifactId>
+    <artifactId>omid-benchmarks-${hbase.artifactId.suffix}</artifactId>
     <name>Benchmarks</name>
 
     <dependencies>
@@ -31,32 +31,22 @@
 
         <dependency>
             <groupId>org.apache.omid</groupId>
-            <artifactId>omid-transaction-client</artifactId>
+            <artifactId>omid-transaction-client-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.omid</groupId>
             <artifactId>omid-hbase-commit-table-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.omid</groupId>
-                    <artifactId>${shims.exclude.artifactId}</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.omid</groupId>
-                    <artifactId>omid-hbase-common-${hbase.exclude.artifactId.suffix}</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.omid</groupId>
-            <artifactId>omid-metrics</artifactId>
+            <artifactId>omid-metrics-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.omid</groupId>
-            <artifactId>omid-codahale-metrics</artifactId>
+            <artifactId>omid-codahale-metrics-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <!-- End of Dependencies on Omid modules -->

--- a/codahale-metrics/pom.xml
+++ b/codahale-metrics/pom.xml
@@ -15,14 +15,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
-        <artifactId>omid</artifactId>
         <groupId>org.apache.omid</groupId>
+        <artifactId>omid-${hbase.artifactId.suffix}</artifactId>
         <version>1.0.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>omid-codahale-metrics</artifactId>
+    <artifactId>omid-codahale-metrics-${hbase.artifactId.suffix}</artifactId>
     <name>Codahale Metrics</name>
 
     <dependencies>
@@ -31,7 +31,7 @@
 
         <dependency>
             <groupId>org.apache.omid</groupId>
-            <artifactId>omid-metrics</artifactId>
+            <artifactId>omid-metrics-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/commit-table/pom.xml
+++ b/commit-table/pom.xml
@@ -18,11 +18,11 @@
 
     <parent>
         <groupId>org.apache.omid</groupId>
-        <artifactId>omid</artifactId>
+        <artifactId>omid-${hbase.artifactId.suffix}</artifactId>
         <version>1.0.2-SNAPSHOT</version>
     </parent>
 
-    <artifactId>omid-commit-table</artifactId>
+    <artifactId>omid-commit-table-${hbase.artifactId.suffix}</artifactId>
     <packaging>jar</packaging>
     <name>Commit Table</name>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -18,11 +18,11 @@
 
     <parent>
         <groupId>org.apache.omid</groupId>
-        <artifactId>omid</artifactId>
+        <artifactId>omid-${hbase.artifactId.suffix}</artifactId>
         <version>1.0.2-SNAPSHOT</version>
     </parent>
 
-    <artifactId>omid-common</artifactId>
+    <artifactId>omid-common-${hbase.artifactId.suffix}</artifactId>
     <name>Common</name>
     <packaging>jar</packaging>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -17,12 +17,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <artifactId>omid</artifactId>
         <groupId>org.apache.omid</groupId>
+        <artifactId>omid-${hbase.artifactId.suffix}</artifactId>
         <version>1.0.2-SNAPSHOT</version>
     </parent>
 
-    <artifactId>omid-examples</artifactId>
+    <artifactId>omid-examples-${hbase.artifactId.suffix}</artifactId>
     <name>Omid Client Examples</name>
     <description>Includes some examples showing Omid features</description>
 
@@ -34,21 +34,11 @@
             <groupId>org.apache.omid</groupId>
             <artifactId>omid-hbase-client-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.omid</groupId>
-                    <artifactId>${shims.exclude.artifactId}</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.omid</groupId>
-                    <artifactId>omid-hbase-commit-table-${hbase.exclude.artifactId.suffix}</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.apache.omid</groupId>
-            <artifactId>omid-codahale-metrics</artifactId>
+            <artifactId>omid-codahale-metrics-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <!-- End of Dependencies on Omid modules -->

--- a/hbase-client/pom.xml
+++ b/hbase-client/pom.xml
@@ -18,7 +18,7 @@
 
     <parent>
         <groupId>org.apache.omid</groupId>
-        <artifactId>omid</artifactId>
+        <artifactId>omid-${hbase.artifactId.suffix}</artifactId>
         <version>1.0.2-SNAPSHOT</version>
     </parent>
 
@@ -33,28 +33,18 @@
 
         <dependency>
             <groupId>org.apache.omid</groupId>
-            <artifactId>omid-common</artifactId>
+            <artifactId>omid-common-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.omid</groupId>
-            <artifactId>omid-transaction-client</artifactId>
+            <artifactId>omid-transaction-client-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.omid</groupId>
             <artifactId>omid-hbase-commit-table-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.omid</groupId>
-                    <artifactId>${shims.exclude.artifactId}</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.omid</groupId>
-                    <artifactId>omid-hbase-common-${hbase.exclude.artifactId.suffix}</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.omid</groupId>
@@ -76,7 +66,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.omid</groupId>
-            <artifactId>omid-commit-table</artifactId>
+            <artifactId>omid-commit-table-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
             <classifier>tests</classifier>
@@ -155,12 +145,6 @@
             <groupId>org.apache.omid</groupId>
             <artifactId>${shims.artifactId}</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.omid</groupId>
-                    <artifactId>${shims.exclude.artifactId}</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- end testing -->

--- a/hbase-commit-table/pom.xml
+++ b/hbase-commit-table/pom.xml
@@ -18,7 +18,7 @@
 
     <parent>
         <groupId>org.apache.omid</groupId>
-        <artifactId>omid</artifactId>
+        <artifactId>omid-${hbase.artifactId.suffix}</artifactId>
         <version>1.0.2-SNAPSHOT</version>
     </parent>
 
@@ -32,24 +32,18 @@
 
         <dependency>
             <groupId>org.apache.omid</groupId>
-            <artifactId>omid-commit-table</artifactId>
+            <artifactId>omid-commit-table-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.omid</groupId>
-            <artifactId>omid-common</artifactId>
+            <artifactId>omid-common-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.omid</groupId>
             <artifactId>omid-hbase-common-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.omid</groupId>
-                    <artifactId>${shims.exclude.artifactId}</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- End of Dependencies on Omid modules -->

--- a/hbase-common/pom.xml
+++ b/hbase-common/pom.xml
@@ -18,7 +18,7 @@
 
     <parent>
         <groupId>org.apache.omid</groupId>
-        <artifactId>omid</artifactId>
+        <artifactId>omid-${hbase.artifactId.suffix}</artifactId>
         <version>1.0.2-SNAPSHOT</version>
     </parent>
 

--- a/hbase-coprocessor/pom.xml
+++ b/hbase-coprocessor/pom.xml
@@ -18,7 +18,7 @@
 
     <parent>
         <groupId>org.apache.omid</groupId>
-        <artifactId>omid</artifactId>
+        <artifactId>omid-${hbase.artifactId.suffix}</artifactId>
         <version>1.0.2-SNAPSHOT</version>
     </parent>
 
@@ -34,16 +34,6 @@
             <groupId>org.apache.omid</groupId>
             <artifactId>omid-hbase-commit-table-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.omid</groupId>
-                    <artifactId>${shims.exclude.artifactId}</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.omid</groupId>
-                    <artifactId>omid-hbase-common-${hbase.exclude.artifactId.suffix}</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.omid</groupId>
@@ -55,16 +45,6 @@
             <groupId>org.apache.omid</groupId>
             <artifactId>omid-hbase-client-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.omid</groupId>
-                    <artifactId>omid-hbase-commit-table-${hbase.exclude.artifactId.suffix}</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.omid</groupId>
-                    <artifactId>${shims.exclude.artifactId}</artifactId>
-                </exclusion>
-            </exclusions>
 
         </dependency>
         <dependency>

--- a/hbase-shims/hbase-1/pom.xml
+++ b/hbase-shims/hbase-1/pom.xml
@@ -18,7 +18,7 @@
 
     <parent>
         <groupId>org.apache.omid</groupId>
-        <artifactId>omid-shims-aggregator</artifactId>
+        <artifactId>omid-shims-aggregator-${hbase.artifactId.suffix}</artifactId>
         <version>1.0.2-SNAPSHOT</version>
     </parent>
 
@@ -36,7 +36,7 @@
 
         <dependency>
             <groupId>org.apache.omid</groupId>
-            <artifactId>omid-common</artifactId>
+            <artifactId>omid-common-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/hbase-shims/hbase-2/pom.xml
+++ b/hbase-shims/hbase-2/pom.xml
@@ -18,7 +18,7 @@
 
     <parent>
         <groupId>org.apache.omid</groupId>
-        <artifactId>omid-shims-aggregator</artifactId>
+        <artifactId>omid-shims-aggregator-${hbase.artifactId.suffix}</artifactId>
         <version>1.0.2-SNAPSHOT</version>
     </parent>
 

--- a/hbase-shims/pom.xml
+++ b/hbase-shims/pom.xml
@@ -18,11 +18,11 @@
 
     <parent>
         <groupId>org.apache.omid</groupId>
-        <artifactId>omid</artifactId>
+        <artifactId>omid-${hbase.artifactId.suffix}</artifactId>
         <version>1.0.2-SNAPSHOT</version>
     </parent>
 
-    <artifactId>omid-shims-aggregator</artifactId>
+    <artifactId>omid-shims-aggregator-${hbase.artifactId.suffix}</artifactId>
     <packaging>pom</packaging>
     <name>Shims Aggregator for HBase</name>
     <modules>

--- a/hbase-tools/pom.xml
+++ b/hbase-tools/pom.xml
@@ -18,7 +18,7 @@
 
     <parent>
         <groupId>org.apache.omid</groupId>
-        <artifactId>omid</artifactId>
+        <artifactId>omid-${hbase.artifactId.suffix}</artifactId>
         <version>1.0.2-SNAPSHOT</version>
     </parent>
 
@@ -34,32 +34,12 @@
             <groupId>org.apache.omid</groupId>
             <artifactId>omid-hbase-commit-table-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.omid</groupId>
-                    <artifactId>${shims.exclude.artifactId}</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.omid</groupId>
-                    <artifactId>omid-hbase-common-${hbase.exclude.artifactId.suffix}</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.apache.omid</groupId>
             <artifactId>omid-timestamp-storage-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.omid</groupId>
-                    <artifactId>${shims.exclude.artifactId}</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.omid</groupId>
-                    <artifactId>omid-hbase-common-${hbase.exclude.artifactId.suffix}</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <!-- End of Dependencies on Omid modules -->
 

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -17,12 +17,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <artifactId>omid</artifactId>
         <groupId>org.apache.omid</groupId>
+        <artifactId>omid-${hbase.artifactId.suffix}</artifactId>
         <version>1.0.2-SNAPSHOT</version>
     </parent>
 
-    <artifactId>omid-metrics</artifactId>
+    <artifactId>omid-metrics-${hbase.artifactId.suffix}</artifactId>
     <name>Metrics</name>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <inceptionYear>2011</inceptionYear>
     <url>http://omid.incubator.apache.org</url>
     <groupId>org.apache.omid</groupId>
-    <artifactId>omid</artifactId>
+    <artifactId>omid-${hbase.artifactId.suffix}</artifactId>
     <packaging>pom</packaging>
     <!-- WARNING: do not update version manually, use mvn versions:set -->
     <version>1.0.2-SNAPSHOT</version>
@@ -145,14 +145,11 @@
 
         <!-- hbase-1 profile props are here and not in profile section to work better with intelij-->
         <shims.artifactId>${shims1.artifactId}</shims.artifactId>
-        <shims.exclude.artifactId>${shims2.artifactId}</shims.exclude.artifactId>
         <java.version>1.7</java.version>
         <hadoop.version>${hadoop1.version}</hadoop.version>
         <hbase.version>${hbase1.version}</hbase.version>
         <shims.module>hbase-1</shims.module>
         <hbase.artifactId.suffix>${hbase1.artifactId.suffix}</hbase.artifactId.suffix>
-        <hbase.exclude.artifactId.suffix>${hbase2.artifactId.suffix}</hbase.exclude.artifactId.suffix>
-
 
         <!-- Basic properties -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -320,6 +317,33 @@
         </pluginManagement>
 
         <plugins>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.2.5</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                </configuration>
+                <executions>
+                    <!-- enable flattening -->
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <!-- ensure proper cleanup -->
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -567,29 +591,16 @@
             </build>
 
         </profile>
-        <profile>
-            <id>hbase-1</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-
-            </properties>
-        </profile>
 
         <profile>
             <id>hbase-2</id>
             <properties>
                 <shims.artifactId>${shims2.artifactId}</shims.artifactId>
-                <shims.exclude.artifactId>${shims1.artifactId}</shims.exclude.artifactId>
                 <shims.module>hbase-2</shims.module>
-                <shims.artifactId>${shims2.artifactId}</shims.artifactId>
                 <java.version>1.8</java.version>
                 <hadoop.version>${hadoop2.version}</hadoop.version>
                 <hbase.version>${hbase2.version}</hbase.version>
                 <hbase.artifactId.suffix>${hbase2.artifactId.suffix}</hbase.artifactId.suffix>
-                <hbase.exclude.artifactId.suffix>${hbase1.artifactId.suffix}</hbase.exclude.artifactId.suffix>
-
             </properties>
         </profile>
 

--- a/statemachine/pom.xml
+++ b/statemachine/pom.xml
@@ -18,12 +18,12 @@
 
     <parent>
         <groupId>org.apache.omid</groupId>
-        <artifactId>omid</artifactId>
+        <artifactId>omid-${hbase.artifactId.suffix}</artifactId>
         <version>1.0.2-SNAPSHOT</version>
     </parent>
 
     <name>State Machine</name>
-    <artifactId>omid-statemachine</artifactId>
+    <artifactId>omid-statemachine-${hbase.artifactId.suffix}</artifactId>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/timestamp-storage/pom.xml
+++ b/timestamp-storage/pom.xml
@@ -18,7 +18,7 @@
 
     <parent>
         <groupId>org.apache.omid</groupId>
-        <artifactId>omid</artifactId>
+        <artifactId>omid-${hbase.artifactId.suffix}</artifactId>
         <version>1.0.2-SNAPSHOT</version>
     </parent>
 
@@ -34,16 +34,10 @@
             <groupId>org.apache.omid</groupId>
             <artifactId>omid-hbase-common-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.omid</groupId>
-                    <artifactId>${shims.exclude.artifactId}</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.omid</groupId>
-            <artifactId>omid-common</artifactId>
+            <artifactId>omid-common-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/transaction-client/pom.xml
+++ b/transaction-client/pom.xml
@@ -18,11 +18,11 @@
 
     <parent>
         <groupId>org.apache.omid</groupId>
-        <artifactId>omid</artifactId>
+        <artifactId>omid-${hbase.artifactId.suffix}</artifactId>
         <version>1.0.2-SNAPSHOT</version>
     </parent>
 
-    <artifactId>omid-transaction-client</artifactId>
+    <artifactId>omid-transaction-client-${hbase.artifactId.suffix}</artifactId>
     <packaging>jar</packaging>
     <name>Transaction Client</name>
 
@@ -32,27 +32,27 @@
 
         <dependency>
             <groupId>org.apache.omid</groupId>
-            <artifactId>omid-common</artifactId>
+            <artifactId>omid-common-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.omid</groupId>
-            <artifactId>omid-statemachine</artifactId>
+            <artifactId>omid-statemachine-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.omid</groupId>
-            <artifactId>omid-commit-table</artifactId>
+            <artifactId>omid-commit-table-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.omid</groupId>
-            <artifactId>omid-metrics</artifactId>
+            <artifactId>omid-metrics-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.omid</groupId>
-            <artifactId>omid-commit-table</artifactId>
+            <artifactId>omid-commit-table-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
             <classifier>tests</classifier>

--- a/tso-server/pom.xml
+++ b/tso-server/pom.xml
@@ -18,7 +18,7 @@
 
     <parent>
         <groupId>org.apache.omid</groupId>
-        <artifactId>omid</artifactId>
+        <artifactId>omid-${hbase.artifactId.suffix}</artifactId>
         <version>1.0.2-SNAPSHOT</version>
     </parent>
 
@@ -33,7 +33,7 @@
 
         <dependency>
             <groupId>org.apache.omid</groupId>
-            <artifactId>omid-commit-table</artifactId>
+            <artifactId>omid-commit-table-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
         </dependency>
 
@@ -41,28 +41,12 @@
             <groupId>org.apache.omid</groupId>
             <artifactId>omid-hbase-common-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.omid</groupId>
-                    <artifactId>${shims.exclude.artifactId}</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.apache.omid</groupId>
             <artifactId>omid-hbase-commit-table-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.omid</groupId>
-                    <artifactId>${shims.exclude.artifactId}</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.omid</groupId>
-                    <artifactId>omid-hbase-common-${hbase.exclude.artifactId.suffix}</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
 
@@ -70,27 +54,17 @@
             <groupId>org.apache.omid</groupId>
             <artifactId>omid-timestamp-storage-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.omid</groupId>
-                    <artifactId>${shims.exclude.artifactId}</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.omid</groupId>
-                    <artifactId>omid-hbase-common-${hbase.exclude.artifactId.suffix}</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.omid</groupId>
-            <artifactId>omid-metrics</artifactId>
+            <artifactId>omid-metrics-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <!-- The codahale-related dependency is added here just to include the jar in the final
         tar.gz package assembled. -->
         <dependency>
             <groupId>org.apache.omid</groupId>
-            <artifactId>omid-codahale-metrics</artifactId>
+            <artifactId>omid-codahale-metrics-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <!-- The hbase-related dependency is added here just to include the jar in the final tar.gz package assembled.
@@ -103,14 +77,14 @@
         </dependency>
         <dependency>
             <groupId>org.apache.omid</groupId>
-            <artifactId>omid-commit-table</artifactId>
+            <artifactId>omid-commit-table-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
             <classifier>tests</classifier>
         </dependency>
         <dependency>
             <groupId>org.apache.omid</groupId>
-            <artifactId>omid-transaction-client</artifactId>
+            <artifactId>omid-transaction-client-${hbase.artifactId.suffix}</artifactId>
             <version>${project.version}</version>
         </dependency>
 


### PR DESCRIPTION
issue: https://issues.apache.org/jira/browse/OMID-188

The main changes are shown below.

1. all artifact has postfix (hbase-1 or hbase-2): phoenix-omid supports both hbase-1 and hbase-2 and they are on different JDK (7 v.s 8). Hence, all artifacts should have postfix to avoid incorrect reference.
1. remove all exclusion rules since the postfix make correct dependencies
1. flatten pom in release file: all variables are replaced by constant