### PR TITLE
OMID-211 Don't leak testing dependencies in hbase shims.

### DIFF
--- a/hbase-shims/pom.xml
+++ b/hbase-shims/pom.xml
@@ -59,6 +59,7 @@
         <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-testing-util</artifactId>
+            <scope>test</scope>
         </dependency>
 
 


### PR DESCRIPTION
HBase-testing-util was scoped as compile dependency, so all users depending on one of the shims will have it on it's classpath, unless they exclude it.

We found this when using Phoenix 5.1 in Cloudera CDP 7.1 in a web application using JAX-RS 2. 
The hbase-testing-util dependencies drags in dependencies on 10-year old JAX-RS 1 api's.

```
[INFO] |  |  +- org.apache.phoenix:phoenix-core:jar:5.1.0.7.1.6.0-297:compile
[INFO] |  |  |  +- org.apache.phoenix.thirdparty:phoenix-shaded-guava:jar:1.0.0.7.1.6.0-297:compile
[INFO] |  |  |  +- org.apache.phoenix:phoenix-hbase-compat-2.4.0:jar:5.1.0.7.1.6.0-297:compile
[INFO] |  |  |  +- org.apache.hadoop:hadoop-yarn-api:jar:3.1.1.7.1.6.0-297:compile
[INFO] |  |  |  +- org.apache.hadoop:hadoop-hdfs-client:jar:3.1.1.7.1.6.0-297:compile
[INFO] |  |  |  +- org.apache.omid:omid-hbase-client-hbase2.x:jar:1.0.2.7.1.6.0-297:compile
[INFO] |  |  |  +- org.apache.omid:omid-hbase-coprocessor-hbase2.x:jar:1.0.2.7.1.6.0-297:compile
[INFO] |  |  |  +- org.apache.omid:omid-hbase-shims-hbase2.x:jar:1.0.2.7.1.6.0-297:compile
[INFO] |  |  |  |  +- org.apache.hbase:hbase-endpoint:jar:2.2.3.7.1.6.0-297:compile
[INFO] |  |  |  |  \- org.apache.hbase:hbase-testing-util:jar:2.2.3.7.1.6.0-297:compile
[INFO] |  |  |  |     +- org.apache.hbase:hbase-server:test-jar:tests:2.2.3.7.1.6.0-297:compile
[INFO] |  |  |  |     |  +- org.apache.hbase:hbase-http:jar:2.2.3.7.1.6.0-297:compile
[INFO] |  |  |  |     |  +- org.glassfish.web:javax.servlet.jsp:jar:2.3.2:compile
[INFO] |  |  |  |     |  |  \- org.glassfish:javax.el:jar:3.0.1-b11:compile
[INFO] |  |  |  |     |  +- javax.servlet.jsp:javax.servlet.jsp-api:jar:2.3.1:compile
[INFO] |  |  |  |     +- org.apache.hadoop:hadoop-hdfs:test-jar:tests:3.1.1.7.1.6.0-297:compile
[INFO] |  |  |  |     \- org.apache.hadoop:hadoop-minicluster:jar:3.1.1.7.1.6.0-297:compile
[INFO] |  |  |  |        +- org.apache.hadoop:hadoop-common:test-jar:tests:3.1.1.7.1.6.0-297:compile
[INFO] |  |  |  |        |  +- javax.servlet.jsp:jsp-api:jar:2.1:runtime
[INFO] |  |  |  |        |  +- com.sun.jersey:jersey-core:jar:1.19:compile
[INFO] |  |  |  |        |  |  \- javax.ws.rs:jsr311-api:jar:1.1.1:compile
```