### PR TITLE
OMID-225 Migrate from log4j1 to reload4j

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -45,7 +45,7 @@
 
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
         </dependency>
 
         <dependency>

--- a/hbase-client/pom.xml
+++ b/hbase-client/pom.xml
@@ -88,7 +88,7 @@
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
+                    <artifactId>slf4j-reload4j</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -142,8 +142,8 @@
         </dependency>
 
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/hbase-commit-table/pom.xml
+++ b/hbase-commit-table/pom.xml
@@ -77,12 +77,6 @@
         <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-client</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- end logging -->
@@ -118,6 +112,16 @@
             <version>${zookeeper.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- end testing -->

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -35,11 +35,11 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
         </dependency>
 
         <!-- end logging -->

--- a/pom.xml
+++ b/pom.xml
@@ -153,13 +153,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- 3rd-Party Library Versioning -->
-        <hbase.version>2.4.10</hbase.version>
-        <hadoop.version>2.10.0</hadoop.version>
+        <hbase.version>2.4.13</hbase.version>
+        <hadoop.version>2.10.2</hadoop.version>
         <phoenix.thirdparty.version>2.0.0</phoenix.thirdparty.version>
         <guice.version>3.0</guice.version>
         <testng.version>6.10</testng.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <log4j.version>1.2.17</log4j.version>
+        <reload4j.version>1.2.22</reload4j.version>
         <netty4.version>4.1.76.Final</netty4.version>
         <!-- com.google repo will be used except on Aarch64 platform. -->
         <protobuf.group>com.google.protobuf</protobuf.group>
@@ -919,13 +919,13 @@
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-log4j12</artifactId>
+                <artifactId>slf4j-reload4j</artifactId>
                 <version>${slf4j.version}</version>
             </dependency>
             <dependency>
-                <groupId>log4j</groupId>
-                <artifactId>log4j</artifactId>
-                <version>${log4j.version}</version>
+                <groupId>ch.qos.reload4j</groupId>
+                <artifactId>reload4j</artifactId>
+                <version>${reload4j.version}</version>
             </dependency>
 
 

--- a/tso-server/pom.xml
+++ b/tso-server/pom.xml
@@ -177,11 +177,11 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
         </dependency>
 
         <!-- end logging -->


### PR DESCRIPTION
Log4J1 is abandoned and has a number of significant CVEs filed for it. [Reload4J](https://reload4j.qos.ch) is a drop in binary compatible replacement for Log4J1 with all known security issues remediated.

Move up `hbase.version` to 2.4.13 and `hadoop.version` to 2.10.2 because those downstream versions have also migrated from log4j1 to reload4j.