### PR TITLE
OMID-227 Upgrade jcommander

### DIFF
--- a/hbase-coprocessor/src/main/java/org/apache/omid/transaction/CompactorUtil.java
+++ b/hbase-coprocessor/src/main/java/org/apache/omid/transaction/CompactorUtil.java
@@ -86,7 +86,7 @@ public class CompactorUtil {
         Config cmdline = new Config();
         JCommander jcommander = new JCommander(cmdline, args);
         if (cmdline.help) {
-            jcommander.usage("CompactorUtil");
+            jcommander.usage();
             System.exit(1);
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
         <mockito.version>1.10.19</mockito.version>
         <disruptor.version>3.2.0</disruptor.version>
         <metrics.version>3.0.1</metrics.version>
-        <jcommander.version>1.35</jcommander.version>
+        <jcommander.version>1.82</jcommander.version>
         <commons.conf.version>1.10</commons.conf.version>
         <hamcrest.version>1.3</hamcrest.version>
         <!-- 2.12+ shades guava -->


### PR DESCRIPTION
Some jcommander versions are on the Snyk naughty list.
https://security.snyk.io/package/maven/com.beust:jcommander

Upgrade it.