### PR TITLE
OMID-258 Bump maven plugins/dependencies to latest

### DIFF
--- a/misc/omid_checks.xml
+++ b/misc/omid_checks.xml
@@ -8,7 +8,7 @@
     from Google Java Style: https://google.github.io/styleguide/javaguide.html.
 
     Omid's style main modifications in Modules below:
-     - LineLength & LeftCurly.maxLineLength: 120 chars instead of 100
+     - LineLength: 120 chars instead of 100
      - Indentation params: 4 spaces instead of 2
      - AbbreviationAsWordInName.allowedAbbreviationLength: 4 instead of 1
  -->
@@ -25,7 +25,10 @@
 	<module name="FileTabCharacter">
 		<property name="eachLine" value="true"/>
 	</module>
-
+	<module name="LineLength">
+		<property name="max" value="120"/>
+		<property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+	</module>
 	<module name="TreeWalker">
 		<module name="OuterTypeFilename"/>
 		<module name="IllegalTokenText">
@@ -38,10 +41,6 @@
 			<property name="allowByTailComment" value="true"/>
 			<property name="allowNonPrintableEscapes" value="true"/>
 		</module>
-		<module name="LineLength">
-			<property name="max" value="120"/>
-			<property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
-		</module>
 		<module name="AvoidStarImport"/>
 		<module name="OneTopLevelClass"/>
 		<module name="NoLineWrap"/>
@@ -50,10 +49,7 @@
 			<property name="tokens" value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
 		</module>
 		<module name="NeedBraces"/>
-		<module name="LeftCurly">
-			<property name="maxLineLength" value="120"/>
-		</module>
-		<module name="RightCurly"/>
+		<module name="LeftCurly"/>
 		<module name="RightCurly">
 			<property name="option" value="alone"/>
 			<property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT"/>
@@ -186,13 +182,10 @@
 			<property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
 		</module>
 		<module name="JavadocMethod">
-			<property name="scope" value="public"/>
+			<property name="accessModifiers" value="public"/>
 			<property name="allowMissingParamTags" value="true"/>
-			<property name="allowMissingThrowsTags" value="true"/>
 			<property name="allowMissingReturnTag" value="true"/>
-			<property name="minLineCount" value="2"/>
 			<property name="allowedAnnotations" value="Override, Test"/>
-			<property name="allowThrowsTagsForSubclasses" value="true"/>
 		</module>
 		<module name="MethodName">
 			<property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>23</version>
+        <version>30</version>
     </parent>
 
     <licenses>
@@ -165,7 +165,6 @@
         <protobuf-java.version>2.5.0</protobuf-java.version>
         <protoc.version>2.5.0</protoc.version>
         <protobuf.plugin.version>0.6.1</protobuf.plugin.version>
-        <os.plugin.version>1.6.2</os.plugin.version>
         <junit.version>4.13.1</junit.version>
         <mockito.version>2.28.2</mockito.version>
         <disruptor.version>3.2.0</disruptor.version>
@@ -180,25 +179,27 @@
         <snakeyaml.version>2.0</snakeyaml.version>
         <beanutils.version>1.9.4</beanutils.version>
         <commons-io.version>2.11.0</commons-io.version>
-        <google.findbugs.version>3.0.1</google.findbugs.version>
         <commons-pool2.version>2.4.2</commons-pool2.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <bouncycastle.version>1.76</bouncycastle.version>
 
+        <!-- Build related plugins -->
+        <os.plugin.version>1.7.1</os.plugin.version>
+        <google.findbugs.version>3.0.2</google.findbugs.version>
+
         <!-- Maven Plugin Versioning -->
-        <maven-assembly-plugin-version>3.1.1</maven-assembly-plugin-version>
         <maven-coveralls-plugin.version>4.1.0</maven-coveralls-plugin.version>
         <maven-cobertura-plugin.version>2.7</maven-cobertura-plugin.version>
         <maven-license-plugin.version>4.3</maven-license-plugin.version>
-        <maven-pmd-plugin.version>3.4</maven-pmd-plugin.version>
-        <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
-        <maven-jxr-plugin.version>2.3</maven-jxr-plugin.version>
-        <maven-findbugs-maven-plugin.version>3.0.1</maven-findbugs-maven-plugin.version>
-        <maven-owasp-plugin.version>6.5.3</maven-owasp-plugin.version>
-        <surefire.version>3.0.0</surefire.version>
+        <maven-pmd-plugin.version>3.21.0</maven-pmd-plugin.version>
+        <maven-checkstyle-plugin.version>3.3.0</maven-checkstyle-plugin.version>
+        <maven-jxr-plugin.version>3.3.0</maven-jxr-plugin.version>
+        <maven-findbugs-maven-plugin.version>3.0.5</maven-findbugs-maven-plugin.version>
+        <maven-owasp-plugin.version>8.4.0</maven-owasp-plugin.version>
+
         <!-- Code coverage properties -->
-        <maven-clover-plugin.version>4.4.1</maven-clover-plugin.version>
-        <maven-sonar-plugin.version>3.9.1.2184</maven-sonar-plugin.version>
+        <maven-clover-plugin.version>4.5.0</maven-clover-plugin.version>
+        <maven-sonar-plugin.version>3.10.0.2594</maven-sonar-plugin.version>
 
         <!-- Licensing properties (for license-maven-plugins) -->
         <license.header>misc/header.txt</license.header>
@@ -243,7 +244,6 @@
 
                 <plugin>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>${maven-assembly-plugin-version}</version>
                     <configuration>
                         <skipAssembly>true</skipAssembly>
                         <descriptors>


### PR DESCRIPTION
- Bump apache parent pom version to 30
- Remove maven-assembly-plugin-version and surefire.version as it is coming from parent pom
- Bump following plugins/dependencies
  - os.plugin.version to 1.7.1
  - google.findbugs.version to 3.0.2
  - maven-pmd-plugin.version to 3.21.0
  - maven-checkstyle-plugin.version to 3.3.0
  - maven-jxr-plugin.version to 3.3.0
  - maven-findbugs-maven-plugin.version to 3.0.5
  - maven-owasp-plugin.version to 8.4.0
  - maven-clover-plugin.version to 4.5.0
  - maven-sonar-plugin.version to 3.10.0.2594
- Also updated omid_checks.xml based on updated checkstyle. Issues based on which changes were made:
  - https://github.com/checkstyle/checkstyle/issues/2116
  - https://github.com/checkstyle/checkstyle/issues/3671
  - https://github.com/checkstyle/checkstyle/issues/7417
  - https://github.com/checkstyle/checkstyle/issues/7329