### PR TITLE
OMID-283 Support for build on mac M1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -779,6 +779,19 @@
                 <protoc.version>2.5.0.2</protoc.version>
             </properties>
         </profile>
+        <profile>
+            <!-- Use Mac x64 version of protoc for Apple Silicon (aarch64) Macs -->
+            <id>osx-aarch64</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <properties>
+                <os.detected.classifier>osx-x86_64</os.detected.classifier>
+            </properties>
+        </profile>
 
         <profile>
             <id>code-coverage</id>


### PR DESCRIPTION
This will activate the profile osx-aarch64 successfully in the MAC M1 OS