### PR TITLE
PHOENIX-7488. Use central repo, not repository.apache.org

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,13 +119,6 @@
         <module>examples</module>
     </modules>
 
-    <repositories>
-        <repository>
-            <id>apache release</id>
-            <url>https://repository.apache.org/content/repositories/releases/</url>
-        </repository>
-    </repositories>
-
     <scm>
         <connection>scm:git:https://gitbox.apache.org/repos/asf/phoenix-omid.git</connection>
         <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/phoenix-omid.git</developerConnection>


### PR DESCRIPTION
## What changes were proposed in this pull request?

[Build](https://github.com/apache/phoenix-omid/actions/runs/11804691762/job/32885469807#step:4:1783) tries to download non-Apache artifacts from `apache release` repo:

```
[INFO] Downloading from apache release: https://repository.apache.org/content/repositories/releases/org/yaml/snakeyaml/2.2/snakeyaml-2.2.pom
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/yaml/snakeyaml/2.2/snakeyaml-2.2.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/yaml/snakeyaml/2.2/snakeyaml-2.2.pom (21 kB at 3.5 MB/s)
```

This change removes `repository.apache.org` definition, to let the build use `central` repo from super POM.

Please see last item about `repository.apache.org` at https://infra.apache.org/infra-ban.html

https://issues.apache.org/jira/browse/PHOENIX-7488

## How was this patch tested?

Local build:

```
$ mvn -DskipTests clean package
...
[INFO] Reactor Summary for Omid 1.1.3-SNAPSHOT:
[INFO] 
[INFO] Omid ............................................... SUCCESS [  1.081 s]
[INFO] Common ............................................. SUCCESS [  2.974 s]
[INFO] State Machine ...................................... SUCCESS [  0.255 s]
[INFO] Commit Table ....................................... SUCCESS [  0.080 s]
[INFO] Metrics ............................................ SUCCESS [  0.091 s]
[INFO] Transaction Client ................................. SUCCESS [  0.420 s]
[INFO] HBase Common ....................................... SUCCESS [ 12.625 s]
[INFO] HBase Commit Table ................................. SUCCESS [  1.204 s]
[INFO] Codahale Metrics ................................... SUCCESS [  0.077 s]
[INFO] Benchmarks ......................................... SUCCESS [  2.629 s]
[INFO] Timestamp Storage .................................. SUCCESS [  0.337 s]
[INFO] HBase tools ........................................ SUCCESS [  0.310 s]
[INFO] TSO and TO Servers ................................. SUCCESS [  4.968 s]
[INFO] HBase Client ....................................... SUCCESS [  0.606 s]
[INFO] HBase Coprocessors ................................. SUCCESS [  1.110 s]
[INFO] Omid Client Examples ............................... SUCCESS [  2.588 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```